### PR TITLE
James/sweagent onboarding for java

### DIFF
--- a/multi_swe_bench/harness/repos/java/__init__.py
+++ b/multi_swe_bench/harness/repos/java/__init__.py
@@ -16,3 +16,4 @@ from multi_swe_bench.harness.repos.java.provectus import *
 from multi_swe_bench.harness.repos.java.OpenRefine import *
 from multi_swe_bench.harness.repos.java.Graylog2 import *
 from multi_swe_bench.harness.repos.java.micronautprojects import *
+from multi_swe_bench.harness.repos.java.springprojects import *

--- a/multi_swe_bench/harness/repos/java/alibaba/fastjson2.py
+++ b/multi_swe_bench/harness/repos/java/alibaba/fastjson2.py
@@ -56,6 +56,11 @@ RUN apt update && apt install -y gnupg ca-certificates git curl
 RUN curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
 RUN apt update && apt install -y zulu8-jdk
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/apache/dubbo.py
+++ b/multi_swe_bench/harness/repos/java/apache/dubbo.py
@@ -52,6 +52,11 @@ ENV LC_ALL=C.UTF-8
 WORKDIR /home/
 RUN apt-get update && apt-get install -y git openjdk-17-jdk
 RUN apt-get install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/elastic/logstash.py
+++ b/multi_swe_bench/harness/repos/java/elastic/logstash.py
@@ -21,7 +21,7 @@ class LogstashImageBase(Image):
         return self._config
 
     def dependency(self) -> Union[str, "Image"]:
-        return "ubuntu:latest"
+        return "ubuntu:22.04"
 
     def image_tag(self) -> str:
         return "base"
@@ -61,6 +61,11 @@ RUN apt update && apt install -y gnupg ca-certificates git curl
 RUN curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
 RUN apt update && apt install -y zulu11-jdk
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/fasterxml/jackson_core.py
+++ b/multi_swe_bench/harness/repos/java/fasterxml/jackson_core.py
@@ -52,6 +52,11 @@ ENV LC_ALL=C.UTF-8
 WORKDIR /home/
 RUN apt-get update && apt-get install -y git openjdk-8-jdk
 RUN apt-get install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/fasterxml/jackson_databind.py
+++ b/multi_swe_bench/harness/repos/java/fasterxml/jackson_databind.py
@@ -52,6 +52,11 @@ ENV LC_ALL=C.UTF-8
 WORKDIR /home/
 RUN apt-get update && apt-get install -y git openjdk-8-jdk
 RUN apt-get install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/fasterxml/jackson_dataformat_xml.py
+++ b/multi_swe_bench/harness/repos/java/fasterxml/jackson_dataformat_xml.py
@@ -52,6 +52,11 @@ ENV LC_ALL=C.UTF-8
 WORKDIR /home/
 RUN apt-get update && apt-get install -y git openjdk-8-jdk
 RUN apt-get install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/google/gson.py
+++ b/multi_swe_bench/harness/repos/java/google/gson.py
@@ -52,6 +52,11 @@ ENV LC_ALL=C.UTF-8
 WORKDIR /home/
 RUN apt-get update && apt-get install -y git openjdk-11-jdk
 RUN apt-get install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/googlecontainertools/jib.py
+++ b/multi_swe_bench/harness/repos/java/googlecontainertools/jib.py
@@ -21,7 +21,7 @@ class JibImageBase(Image):
         return self._config
 
     def dependency(self) -> Union[str, "Image"]:
-        return "ubuntu:latest"
+        return "ubuntu:22.04"
 
     def image_tag(self) -> str:
         return "base"
@@ -62,6 +62,11 @@ RUN curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/k
     && echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
 RUN apt update && apt install -y zulu11-jdk
 RUN apt install -y maven
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/mockito/mockito.py
+++ b/multi_swe_bench/harness/repos/java/mockito/mockito.py
@@ -21,7 +21,7 @@ class MockitoImageBase(Image):
         return self._config
 
     def dependency(self) -> Union[str, "Image"]:
-        return "ubuntu:latest"
+        return "ubuntu:22.04"
 
     def image_tag(self) -> str:
         return "base"
@@ -61,6 +61,11 @@ RUN apt update && apt install -y gnupg ca-certificates git curl
 RUN curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
 RUN apt update && apt install -y zulu21-jdk
+# install swe-rex for sweagent:
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN pip3 install pipx && \
+    pipx ensurepath && \
+    pipx install swe-rex
 
 {code}
 

--- a/multi_swe_bench/harness/repos/java/springprojects/springboot.py
+++ b/multi_swe_bench/harness/repos/java/springprojects/springboot.py
@@ -21,7 +21,7 @@ class SpringBootImageBase(Image):
         return self._config
 
     def dependency(self) -> Union[str, "Image"]:
-        return "ubuntu:latest"
+        return "ubuntu:22.04"
 
     def image_tag(self) -> str:
         return "base"


### PR DESCRIPTION
I have update the java base images to include dependencies required to run sweagent. 
The base images for each java repo have been built and pushed to https://hub.docker.com/r/omnicodeorg/omnicode/tags. 
Feel free to pull those images and test run them for sweagent on g2. 